### PR TITLE
With Latest From Publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,36 @@ NotificationCenter.default.publisher(for: [Notification.Name.CartUpdate, Notific
     .store(in: &subscriptions)
 ```
 
+### `withLatestFrom` Operator
+
+Merges two publishers into a single publisher by combining each value from `self` with the _latest_ value from the other publisher, if any.
+
+```swift
+let buttonTap = PassthroughSubject<Void, Never>()
+let formData = CurrentValueSubject<FormData, Never>()
+
+let publisher = buttonTap
+    .withLatestFrom(formData)
+    .sink { _, formData in 
+        //
+    }
+}
+
+buttonTap.send()
+formData.send(formData.updated()) // Won't trigger publisher, waiting on buttonTap to send again.
+formData.send(formData.updated())
+formData.send(formData.updated())
+buttonTap.send()
+```
+
 
 ## Documentation
 
+<<<<<<< HEAD
 `CombineExtensions` has full DocC documentation. After adding to your project, `Build Documentation` to add to your documentation viewer.
+=======
+CombineExtensions has full DocC documentation. After adding to your project, `Build Documentation` to add to your documentation viewer.
+>>>>>>> 9a6f27d (updated tests)
 
 ## Communication
 

--- a/Tests/CombineExtensionsTests/WithLatestFromTests.swift
+++ b/Tests/CombineExtensionsTests/WithLatestFromTests.swift
@@ -8,26 +8,24 @@
 import Foundation
 import Combine
 import XCTest
+@testable import CombineExtensions
 
 final class WithLatestFromTests: XCTestCase {
 
     var subscriptions = Set<AnyCancellable>()
 
-    func test_compound_one() {
+    func testOperatorExtension() {
 
         // Given
         let primary = PassthroughSubject<String, Never>()
-        let secondary = CurrentValueSubject<Int, Never>(0)
+        let secondary = PassthroughSubject<Int, Never>()
 
-        let queueA = DispatchQueue(label: "A")
-        let queueB = DispatchQueue(label: "B")
-
-        let publisher = primary.receive(on: queueA).withLatestFrom(secondary).receive(on: queueB)
+        let publisher = primary.withLatestFrom(secondary)
 
         // When
         var capturedValues = [String]()
         publisher
-            .map { "\($0)-\($1)" }
+            .map { $0 + $1.description }
             .sink { value in
                 capturedValues.append(value)
             }
@@ -36,89 +34,108 @@ final class WithLatestFromTests: XCTestCase {
         secondary.send(1)
         primary.send("A")
         secondary.send(100) // Won't trigger publisher, waiting on primary to send again.
+        secondary.send(200)
         secondary.send(2)
         primary.send("B")
 
-
-
         // Then
-        XCTAssertEqual(capturedValues, ["A-1", "B-2"])
+        XCTAssertEqual(capturedValues, ["A1", "B2"])
     }
 
-    func test_withLatestFrom_doesnt_publish_when_secondary_updates() {
+    func testPubisherCompletesWhenUpstreamCompletes() {
 
-        // Given
         let primary = PassthroughSubject<String, Never>()
-        let secondary = CurrentValueSubject<Int, Never>(0)
+        let secondary = PassthroughSubject<String, Never>()
 
-        let publisher = Publishers.WithLatestFrom(upstream: primary, second: secondary).eraseToAnyPublisher()
-
-        // When
-        var capturedValues = [String]()
-        publisher
-            .map { "\($0)-\($1)" }
-            .sink { value in
-                capturedValues.append(value)
-            }
+        var completed = false
+        var results = [String]()
+        primary
+            .withLatestFrom(secondary)
+            .map { $0 + $1 }
+            .sink(
+                receiveCompletion: { _ in
+                    completed = true
+                },
+                receiveValue: { results.append($0) }
+            )
             .store(in: &subscriptions)
 
-        secondary.send(1)
+
+        secondary.send("1")
         primary.send("A")
-        secondary.send(100) // Won't trigger publisher, waiting on primary to send again.
-        secondary.send(2)
+        secondary.send("2")
+        secondary.send("3")
         primary.send("B")
 
-        // Then
-        XCTAssertEqual(capturedValues, ["A-1", "B-2"])
+        XCTAssertEqual(results, ["A1", "B3"])
+
+        XCTAssertFalse(completed)
+        secondary.send(completion: .finished)
+
+        XCTAssertFalse(completed)
+        primary.send(completion: .finished)
+
+        XCTAssertTrue(completed)
     }
 
 
-    func test_withLatestFrom_doesnt_publish_when_secondary_updates_queue() {
+    func testPublisherInializer() {
 
-        let object = MockObject<(String)>(fulfillCount: 2)
+        let primary = PassthroughSubject<String, Never>()
+        let secondary = PassthroughSubject<String, Never>()
+
+        let publisher = Publishers.WithLatestFrom(upstream: primary, secondary: secondary)
+
+        XCTAssertEqual(ObjectIdentifier(publisher.upstream), ObjectIdentifier(primary))
+        XCTAssertEqual(ObjectIdentifier(publisher.second), ObjectIdentifier(secondary))
+    }
+
+    func testPublisherReceivesSubscriber() {
 
         // Given
-        let primary = PassthroughSubject<String, Never>()
-        let secondary = CurrentValueSubject<Int, Never>(0)
+        let publisher = Publishers.WithLatestFrom(upstream: Just(""), secondary: Just(""))
 
-        let queueA = DispatchQueue(label: "A")
-        let queueB = DispatchQueue(label: "B")
+        var subscriptionDescription: String?
 
-        /*
-
-         Different Queues, doesn't work
-            upstream: primary.receive(on: queueB),
-            second: secondary.receive(on: queueA)
-
-         Different Queues, doesn't work
-            upstream: primary.subscribe(on: queueB),
-            second: secondary.subscribe(on: queueA)
-         */
-        
-        let publisher = Publishers.WithLatestFrom(
-            upstream: primary.subscribe(on: queueB),
-            second: secondary
-        ).eraseToAnyPublisher()
+        let subscriber = AnySubscriber<(String, String), Never>(
+            receiveSubscription: { subscription in
+                subscriptionDescription = String(describing: subscription)
+            },
+            receiveValue: nil,
+            receiveCompletion: nil
+        )
 
         // When
-        publisher
-            .receive(on: queueA)
-            .map { "\($0)-\($1)" }
-            .sink(receiveValue: object.functionWithOneParemeter)
-            .store(in: &subscriptions)
-
-        secondary.send(1)
-        primary.send("A")
-        secondary.send(100) // Won't trigger publisher, waiting on primary to send again.
-        secondary.send(2)
-        primary.send("B")
-
-        wait(for: object, timeout: 20.0)
+        publisher.receive(subscriber: subscriber)
 
         // Then
-        XCTAssertEqual(object.capturedValues, ["A-1", "B-2"])
+        XCTAssertEqual(subscriptionDescription, "Publishers.WithLatestFrom<(String, String), Never>.Subscription")
     }
 
+    func testSubscriberRetainsPublishers() {
 
+        var primary: PassthroughSubject<Int, Never>? = .init()
+        var secondary: PassthroughSubject<Int, Never>? = .init()
+
+        weak var weakPrimary = primary
+        weak var weakSecondary = secondary
+
+        let subscription = weakPrimary!
+            .withLatestFrom(weakSecondary!)
+            .sink { _ in }
+
+        // When
+        primary = nil
+        secondary = nil
+
+        XCTAssertNotNil(weakPrimary)
+        XCTAssertNotNil(weakSecondary)
+
+        subscription.cancel()
+
+        // Then
+        XCTAssertNil(weakPrimary)
+        XCTAssertNil(weakSecondary)
+    }
 }
 


### PR DESCRIPTION
### What:
Added a `withLatestFrom` publisher which captures the latest value of the provided publisher. 

### Why:
Useful for injecting publishers into pipelines that don't trigger publishers by themselves. 

### How:
Created custom Publisher/Subscriber using the CombineCommunity/CombineExt project as a guide. 

### Testing Notes
Added tests for the publisher and subscriber. May need to revisit them to add some stress testing later.

### Testing Notes
{Replace with any applicable testing notes.}
